### PR TITLE
All interface members are public by default

### DIFF
--- a/GavAnimeAPI/Clients/IDynamoDbClient.cs
+++ b/GavAnimeAPI/Clients/IDynamoDbClient.cs
@@ -5,8 +5,8 @@ namespace GavAnimeAPI.Clients;
 
 public interface IDynamoDbClient
 {
-    public Task<AnimeDbRepository> GetDataById(string id, string userId);
-    public Task<List<AnimeDbRepository>> GetFavoriteAnimeList(string userId);
-    public Task<bool> PutAnime(AnimeDbRepository anime);
-    public Task<bool> DeleteAnime(AnimeDbRepository anime, string userId);
+    Task<AnimeDbRepository> GetDataById(string id, string userId);
+    Task<List<AnimeDbRepository>> GetFavoriteAnimeList(string userId);
+    Task<bool> PutAnime(AnimeDbRepository anime);
+    Task<bool> DeleteAnime(AnimeDbRepository anime, string userId);
 }


### PR DESCRIPTION
So you do not need to use public modifier to make the code prettier. Moreover in C# all async methods need to be decorated with Async word on the end like GetDataByIdAsync